### PR TITLE
Treat yadism matching data as level-2 closure test data

### DIFF
--- a/src/nnusf/sffit/load_data.py
+++ b/src/nnusf/sffit/load_data.py
@@ -48,9 +48,7 @@ def load_experimental_data(
 
 
 def add_pseudodata(experimental_datasets, shift=True):
-    """`matching_seed` is used to generate the level-1 fluctuation in the
-    matching pseudodat.
-    If `shift=False` no pseudodata is generated and real data is used
+    """If `shift=False` no pseudodata is generated and real data is used
     instead. This is only relevant for debugging purposes.
     """
     for dataset in experimental_datasets.values():


### PR DESCRIPTION
This accounts for the fact that unlike experimental data, matching data doesn't contain sampling fluctuations. With this implemented the spread of both matching and experimental data is of similar scale/order.

Resolves #55 